### PR TITLE
added instance folder support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ target/
 
 #emacs
 *~
+
+# Flask Instance Folder
+instance

--- a/config.py
+++ b/config.py
@@ -2,8 +2,9 @@ import os
 
 class Config(object):
     # configuration
-    NAME = "PRODUCTION"
-    SECRET_KEY = '\x00\xb47\xb1\x1b<*tx\x1b2ywW\x86\x01\xfa\xcd\x0b\xeb\x94\x1c\xe5\xaf'
+    NAME = "DEBUG"
+    SECRET_KEY = 'shh'
+    DEBUG = True
     MAIL_SERVER = "smtp.gmail.com"
     MAIL_USERNAME = "KentonCountyLibrary@gmail.com"
     MAIL_PASSWORD = "CincyPyCoders"
@@ -11,16 +12,14 @@ class Config(object):
     MAIL_USE_TLS = True
     MAIL_DEFAULT_SENDER = "KentonCountyLibrary@gmail.com"
 
-    DBPATH = "sqlite:///library.db"
-    DBFILE = "library.db"
+    SQLALCHEMY_DATABASE_URI = "sqlite:///library.db"
 
     def __init__(self):
         print "Config environment is: " + self.NAME
     
 class TestConfig(Config):
     NAME = "TEST"
-    DBPATH = "sqlite://"
-    DBFILE = ""
+    SQLALCHEMY_DATABASE_URI = "sqlite://"
 
 config = None
 if os.environ.get("LIBRARY_ENV",None) == "test":

--- a/database.py
+++ b/database.py
@@ -1,11 +1,9 @@
 from sqlalchemy import create_engine, event
 from sqlalchemy.engine import Engine
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
 from config import config
 
-SQLITE_DATABASE_PATH = config.DBPATH
-SQLITE_DATABASE_FILE = config.DBFILE
+from models import Base
 
 # Enable Foreign Key Support in sqlite
 @event.listens_for(Engine, "connect")
@@ -14,12 +12,47 @@ def set_sqlite_pragma(dbapi_connection, connection_record):
     cursor.execute("PRAGMA foreign_keys=ON")
     cursor.close()
 
-engine = create_engine(SQLITE_DATABASE_PATH, convert_unicode=True)
-db_session = scoped_session(sessionmaker(autocommit=False,
-                                         autoflush=False,
-                                         bind=engine))
-Base = declarative_base()
-Base.query = db_session.query_property()
+class Database(object):
+    """
+    An extremely simplified version of Flask-SQLAlchemy
+    """
+
+    def __init__(self, app=None):
+        self._session = None
+        self.engine = None
+        self.app = None
+
+        if app is not None:
+            self.init_app(app)
+
+    @property
+    def session(self):
+        # either instantiate class with app or init_app before accessing the session property
+        if self._session is not None:
+            return self._session
+        return self.create_session()
+
+    def create_session(self):
+        uri = self.app.config['SQLALCHEMY_DATABASE_URI']
+        self.engine = engine = create_engine(uri, convert_unicode=True)
+        maker = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+        self._session = scoped_session(maker)
+        return self._session
+
+    def init_app(self, app):
+        self.app = app
+        app.config.setdefault('SQLALCHEMY_DATABASE_URI', 'sqlite://')
+
+        Base.query = self.session.query_property()
+
+        @app.teardown_appcontext
+        def shutdown_session(response_or_exc):
+            if app.config.get('SQLALCHEMY_COMMIT_ON_TEARDOWN'):
+                if response_or_exc is None:
+                    self.session.commit()
+            self.session.remove()
+            return response_or_exc
+
 
 def init_db():
     import models

--- a/models.py
+++ b/models.py
@@ -1,12 +1,13 @@
 import argparse
 import datetime
 import os
-import os.path
+import sys
 
 from sqlalchemy import Boolean, Column, Date, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import backref, relationship
+from sqlalchemy.ext.declarative import declarative_base
 
-from database import Base, SQLITE_DATABASE_PATH, SQLITE_DATABASE_FILE, engine, init_db
+Base = declarative_base()
 
 class Staff(Base):
     __tablename__ = 'staff'
@@ -23,24 +24,25 @@ class Staff(Base):
     phone = Column(Boolean, default=True)
     chat = Column(Boolean, default=False)
     irl = Column(Boolean, default=True)
-    
+
     interests = Column(Text)
 
     patron_contacts = relationship('PatronContact', backref=backref('staff', uselist=False))
 
     def __getitem__(self, attr):
         return getattr(self, attr)
-    
-    @property 
+
+    @property
     def category_list(self):
         return set([item.category for item in self.readinglist])
 
     def profile_path(self):
         if os.path.isfile('static/uploads/' + self.username + '.jpg'):
             pic_file_name = 'uploads/'+ self.username + '.jpg'
-        else: 
+        else:
             pic_file_name = 'uploads/anon.jpg'
         return pic_file_name
+
 
 class ReadingList(Base):
     __tablename__ = 'readinglist'
@@ -83,13 +85,10 @@ class PatronContact(Base):
         return getattr(self, attr)
 
 
-def init_models(db_session=None):
-    if db_session is None:
-        from database import db_session
-
+def init_models(session):
     admin = Staff(username='admin', password='admin', f_name='Admin', emailaddress='KentonCountyLibrary@gmail.com',
                   l_name='User', phonenumber=1111111111, bio='Admin bio')
-    db_session.add(admin)
+    session.add(admin)
 
     fred = Staff(username='fred', password='fred', f_name='Fred', emailaddress='KentonCountyLibrary@gmail.com',
                  l_name='Fredderson', phonenumber=2222222222, bio='I am Fred\'s incomplete bio',
@@ -116,39 +115,39 @@ def init_models(db_session=None):
                       category='Sci-fi')
     fred.readinglist.append(rl1)
     fred.readinglist.append(rl2)
-    db_session.add(fred)
+    session.add(fred)
 
     loremipsum = '''Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'''
 
-    db_session.add(Staff(username='ernie',
+    session.add(Staff(username='ernie',
                          password='ernie',
                          f_name='Ernie',
                          l_name='Ernieston',
                          phonenumber=3333333333,
                          emailaddress='KentonCountyLibrary@gmail.com',
                          bio=loremipsum))
-    db_session.add(Staff(username='bert',
+    session.add(Staff(username='bert',
                          password='bert',
                          f_name='Bert',
                          l_name='Burterson',
                          phonenumber=4444444444,
                          emailaddress='KentonCountyLibrary@gmail.com',
                          bio=loremipsum))
-    db_session.add(Staff(username='bigbird',
+    session.add(Staff(username='bigbird',
                          password='bigbird',
                          f_name='Big',
                          l_name='Bird',
                          phonenumber=5555555555,
                          emailaddress='KentonCountyLibrary@gmail.com',
                          bio=loremipsum))
-    db_session.add(Staff(username='oscar',
+    session.add(Staff(username='oscar',
                          password='oscar',
                          f_name='Oscar',
                          l_name='Thegrouch',
                          phonenumber=6666666666,
                          emailaddress='KentonCountyLibrary@gmail.com',
                          bio=loremipsum))
-    db_session.add(Staff(username='elmo',
+    session.add(Staff(username='elmo',
                          password='elmo',
                          f_name='Elmo',
                          l_name='Elmostein',
@@ -156,8 +155,8 @@ def init_models(db_session=None):
                          emailaddress='KentonCountyLibrary@gmail.com',
                          bio=loremipsum))
 
-    db_session.commit()
-    db_session.query(Staff).get('elmo').readinglist = [
+    session.commit()
+    session.query(Staff).get('elmo').readinglist = [
         ReadingList(
             recdate=datetime.date(2015,12,21),
             ISBN='9789380028293',
@@ -174,27 +173,54 @@ def init_models(db_session=None):
             category='Music')
     ]
 
-    db_session.commit()
+    session.commit()
 
 def ArgParser():
-    parser = argparse.ArgumentParser(
-        description=('create and initialize with data a new database for the'
-                     ' library web app'))
+    parser = argparse.ArgumentParser(description=main.__doc__)
     _a = parser.add_argument
     _a('--echo', action='store_true', help='echo SQL')
     return parser
 
-if __name__ == '__main__':
+def main():
+    """
+    If a sqlite file can be found in the database URI of the app, prompt to
+    remove it, if found on the filesystem, and then create it with the database
+    structure and initial data.
+    """
+    from library import app, db
+
     parser = ArgParser()
-    args = parser.parse_args()
+    cmdargs = parser.parse_args()
 
-    if os.path.exists(SQLITE_DATABASE_FILE):
-        if raw_input('Remove "%s" ?' % SQLITE_DATABASE_FILE).lower().startswith('y'):
-            os.remove(SQLITE_DATABASE_FILE)
+    def raise_unable_to_parse(uri):
+        raise RuntimeError('unable to parse URI: %s' % uri)
+
+    def confirm(msg):
+        return raw_input(msg).lower().startswith('y')
+
+    def abort():
+        sys.exit('aborted')
+
+    uri = db.engine.url
+
+    if 'sqlite' not in db.engine.driver:
+        raise_unable_to_parse(uri)
+
+    dbargs = db.engine.url.translate_connect_args()
+    path = os.path.abspath(dbargs['database'])
+
+    if os.path.exists(path):
+        if confirm('Remove database file "%s"? ' % path):
+            os.remove(path)
         else:
-            raise RuntimeError('"%s" exists.' % SQLITE_DATABASE_FILE)
+            abort()
+    else:
+        if not confirm('Create database file "%s"? ' % os.path.abspath(path)):
+            abort()
 
-    engine.echo = args.echo
+    db.engine.echo = cmdargs.echo
+    Base.metadata.create_all(bind=db.engine)
+    init_models(db.session)
 
-    Base.metadata.create_all(bind=engine)
-    init_models()
+if __name__ == '__main__':
+    main()

--- a/shell.py
+++ b/shell.py
@@ -1,6 +1,6 @@
 from sqlalchemy import inspect
 
 from models import *
-from library import app
+from library import app, db
 
 app.app_context().push()

--- a/tests.py
+++ b/tests.py
@@ -6,7 +6,6 @@ from ipaddress import ip_network
 
 import library
 from publisher import Publisher
-from database import db_session
 from sqlalchemy import or_, and_
 import models
 import flask
@@ -21,12 +20,13 @@ if os.environ.get("LIBRARY_ENV",None) != "test":
 class LibrarySiteTests(unittest.TestCase):
 
     def setUp(self):
-        models.Base.metadata.create_all(bind=models.engine)
-        models.init_models()
+        models.Base.metadata.create_all(bind=library.db.engine)
         self.app = library.app.test_client()
+        models.init_models(library.db.session)
+        self.session = library.db.session
 
     def tearDown(self):
-        models.Base.metadata.drop_all(bind=models.engine)
+        models.Base.metadata.drop_all(bind=library.db.engine)
 
     def login(self,u,p):
          response = self.app.post('/login', data=dict(
@@ -450,7 +450,7 @@ class LibrarySiteTests(unittest.TestCase):
             sticky=0,
             category="category")
         fred.readinglist.append(readinglist)
-        db_session.commit()
+        self.session.commit()
         rlid = readinglist.RLID
         #try another user
         self.logout()
@@ -544,8 +544,8 @@ class LibrarySiteTests(unittest.TestCase):
         #Add chat and email options to fred's contact preferences
         staff = models.Staff.query.get('fred')
         staff.chat, staff.email = True, True
-        db_session.add(staff)
-        db_session.commit()
+        self.session.add(staff)
+        self.session.commit()
         response = self.app.get("/contact/fred")
         self.assertIn("Online Chat",response.data)
         


### PR DESCRIPTION
To get secret keys and such out of the tracked config, the app will read in `instance/production.py` if it exists (and not configured for testing).

Changed the database interface to a very limited version of Flask-SQLAlchemy, so it will read what it needs out of `app.config` just in time and doesn't need to create a session when imported.
