### PR TITLE
Fix password migration

### DIFF
--- a/migration/00_hashpasswords.py
+++ b/migration/00_hashpasswords.py
@@ -39,10 +39,9 @@ def update_passwords():
 
             hashed = hashpassword(plaintext)
 
-            assert bcrypt.hashpw(encode(plaintext), hashed) == hashed
-
             # Have to sneak around the Staff class to get at the literal database value.
-            conn.execute(text('update staff set password = :hashed'), hashed=hashed)
+            sql = text('update staff set password = :hashed where username = :username')
+            conn.execute(sql, hashed=hashed, username=staff.username)
 
         db.session.commit()
 

--- a/migration/00_hashpasswords.py
+++ b/migration/00_hashpasswords.py
@@ -1,9 +1,10 @@
 import re
 import argparse
+import bcrypt
 from sqlalchemy.sql import text
 
 try:
-    from passwordtype import hashpassword
+    from passwordtype import hashpassword, encode
     from library import app, db
     from models import Staff
 except ImportError:
@@ -36,9 +37,12 @@ def update_passwords():
             if ishashed(plaintext):
                 continue
 
+            hashed = hashpassword(plaintext)
+
+            assert bcrypt.hashpw(encode(plaintext), hashed) == hashed
+
             # Have to sneak around the Staff class to get at the literal database value.
-            conn.execute(text('update staff set password = :hashed'),
-                         hashed=hashpassword(plaintext))
+            conn.execute(text('update staff set password = :hashed'), hashed=hashed)
 
         db.session.commit()
 


### PR DESCRIPTION
Fixed migration to hash old passwords. `migration/00_hashpasswords.py` was not using the primary key to update the users.
